### PR TITLE
Make description optional

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/Replicate/Model.swift
+++ b/Sources/Replicate/Model.swift
@@ -63,7 +63,7 @@ public struct Model: Hashable {
     public let licenseURL: URL?
 
     /// A description for the model.
-    public let description: String
+    public let description: String?
 
     /// The visibility of the model.
     public let visibility: Visibility


### PR DESCRIPTION
Hit a model that was missing a description, causing model loading to fail
Also, fix Xcode warning about whitespace in swift tools line in Package.swift