### PR TITLE
Add `run` method to `Client`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ and passing it to `Client(token:)`:
 import Foundation
 import Replicate
 
-let client = Client(token: <#token#>)
+let replicate = Replicate.Client(token: <#token#>)
 ```
 
 You can run a model and get its output:
 
 ```swift
-let model = try await client.getModel("stability-ai/stable-diffusion")
+let model = try await replicate.getModel("stability-ai/stable-diffusion")
 if let latestVersion = model.latestVersion {
     let prompt = """
         a 19th century portrait of a wombat gentleman
     """
-    let prediction = try await client.createPrediction(version: latestVersion.id,
+    let prediction = try await replicate.createPrediction(version: latestVersion.id,
                                                        input: ["prompt": "\(prompt)"],
                                                        wait: true)
     print(prediction.output)
@@ -45,11 +45,11 @@ read the contents of the file into a `Data` object,
 and use the `uriEncoded(mimeType:) helper method to create a URI-encoded string.
 
 ```swift
-let model = try await client.getModel("tencentarc/gfpgan")
+let model = try await replicate.getModel("tencentarc/gfpgan")
 if let latestVersion = model.latestVersion {
     let data = try! Data(contentsOf: URL(fileURLWithPath: "/path/to/image.jpg"))
     let mimeType = "image/jpeg"
-    let prediction = try await client.createPrediction(version: latestVersion.id,
+    let prediction = try await replicate.createPrediction(version: latestVersion.id,
                                                        input: ["img": "\(data.uriEncoded(mimeType: mimeType))"])
     print(prediction.output)
     // https://replicate.com/api/models/tencentarc/gfpgan/files/85f53415-0dc7-4703-891f-1e6f912119ad/output.png
@@ -59,17 +59,17 @@ if let latestVersion = model.latestVersion {
 You can start a model and run it in the background:
 
 ```swift
-let model = client.getModel("kvfrans/clipdraw")
+let model = replicate.getModel("kvfrans/clipdraw")
 
 let prompt = """
     Watercolor painting of an underwater submarine
 """
-var prediction = client.createPrediction(version: model.latestVersion!.id,
+var prediction = replicate.createPrediction(version: model.latestVersion!.id,
                                          input: ["prompt": "\(prompt)"])
 print(prediction.status)
 // "starting"
 
-try await prediction.wait(with: client)
+try await prediction.wait(with: replicate)
 print(prediction.status)
 // "succeeded"
 ```
@@ -77,17 +77,17 @@ print(prediction.status)
 You can cancel a running prediction:
 
 ```swift
-let model = client.getModel("kvfrans/clipdraw")
+let model = replicate.getModel("kvfrans/clipdraw")
 
 let prompt = """
     Watercolor painting of an underwater submarine
 """
-var prediction = client.createPrediction(version: model.latestVersion!.id,
+var prediction = replicate.createPrediction(version: model.latestVersion!.id,
                                          input: ["prompt": "\(prompt)"])
 print(prediction.status)
 // "starting"
 
-try await prediction.cancel(with: client)
+try await prediction.cancel(with: replicate)
 print(prediction.status)
 // "canceled"
 ```
@@ -96,11 +96,11 @@ You can list all the predictions you've run:
 
 ```swift
 var predictions: [Prediction] = []
-var cursor: Client.Pagination<Prediction>.Cursor?
+var cursor: Replicate.Client.Pagination<Prediction>.Cursor?
 let limit = 100
 
 repeat {
-    let page = try await client.getPredictions(cursor: cursor)
+    let page = try await replicate.getPredictions(cursor: cursor)
     predictions.append(contentsOf: page.results)
     cursor = page.next
 } while predictions.count < limit && cursor != nil
@@ -232,7 +232,7 @@ you can now create predictions for the model with fully type-checked Swift code:
 var input = StableDiffusion.Input(prompt: "multicolor hyperspace")
 input.numOutputs = 4
 
-let prediction = try await StableDiffusion.predict(with: client, input: input)
+let prediction = try await StableDiffusion.predict(with: replicate, input: input)
 
 // `StableDiffusion.Output` is a typealias for `[URL]`
 for url in prediction.output ?? [] {

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ let replicate = Replicate.Client(token: <#token#>)
 You can run a model and get its output:
 
 ```swift
+let output = try await replicate.run(
+    "stability-ai/stable-diffusion:db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf", 
+    ["prompt": "a 19th century portrait of a wombat gentleman"]
+)
+
+print(output)
+// https://replicate.com/api/models/stability-ai/stable-diffusion/files/50fcac81-865d-499e-81ac-49de0cb79264/out-0.png
+```
+
+Or fetch a model by name and create a prediction against its latest version:
+
+```swift
 let model = try await replicate.getModel("stability-ai/stable-diffusion")
 if let latestVersion = model.latestVersion {
     let prompt = """
@@ -83,7 +95,7 @@ let prompt = """
     Watercolor painting of an underwater submarine
 """
 var prediction = replicate.createPrediction(version: model.latestVersion!.id,
-                                         input: ["prompt": "\(prompt)"])
+                                            input: ["prompt": "\(prompt)"])
 print(prediction.status)
 // "starting"
 

--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -25,6 +25,41 @@ public class Client {
         self.token = token
     }
 
+    /// Runs a model and waits for its output.
+    ///
+    /// - Parameters:
+    ///    - identifier:
+    ///        The model version identifier in the format "{owner}/{name}:{version}"
+    ///    - input:
+    ///        The input depends on what model you are running.
+    ///
+    ///        To see the available inputs,
+    ///        click the "Run with API" tab on the model you are running.
+    ///        For example, stability-ai/stable-diffusion
+    ///        takes `prompt` as an input.
+    ///    - webhook:
+    ///         A webhook that is called when the prediction has completed.
+    ///
+    ///         It will be a `POST` request where
+    ///         the request body is the same as
+    ///         the response body of the get prediction endpoint.
+    ///         If there are network problems,
+    ///         we will retry the webhook a few times,
+    ///         so make sure it can be safely called more than once.
+    public func run<Input: Codable, Output: Codable>(
+        _ identifier: Identifier,
+        input: Input,
+        webhook: URL? = nil,
+        _ type: Output.Type = AnyCodable
+    ) async throws -> Output? {
+        let prediction = try await createPrediction(Prediction<Input, Output>.self,
+                                                    version: identifier.version,
+                                                    input: input,
+                                                    webhook: webhook,
+                                                    wait: true)
+        return prediction.output
+    }
+
     /// Create a prediction
     ///
     /// - Parameters:

--- a/Sources/Replicate/Identifier.swift
+++ b/Sources/Replicate/Identifier.swift
@@ -1,0 +1,60 @@
+/// An identifier in the form of "{owner}/{name}:{version}".
+public struct Identifier: Hashable {
+    /// The name of the user or organization that owns the model.
+    public let owner: String
+
+    /// The name of the model.
+    public let name: String
+
+    /// The version.
+    let version: Model.Version.ID
+}
+
+// MARK: - Equatable & Comparable
+
+extension Identifier: Equatable, Comparable {
+    public static func == (lhs: Identifier, rhs: Identifier) -> Bool {
+        return lhs.rawValue.caseInsensitiveCompare(rhs.rawValue) == .orderedSame
+    }
+
+    public static func < (lhs: Identifier, rhs: Identifier) -> Bool {
+        return lhs.rawValue.caseInsensitiveCompare(rhs.rawValue) == .orderedAscending
+    }
+}
+
+// MARK: - RawRepresentable
+
+extension Identifier: RawRepresentable {
+    public typealias RawValue = String
+
+    public init?(rawValue: RawValue) {
+        let components = rawValue.split(separator: "/")
+        guard components.count == 2 else { return nil }
+
+        let owner = String(components[0])
+
+        let nameAndVersion = components[1].split(separator: ":")
+        guard nameAndVersion.count == 2 else { return nil }
+
+        let name = String(nameAndVersion[0])
+        let version = Model.Version.ID(nameAndVersion[1])
+
+        self.init(owner: owner, name: name, version: version)
+    }
+
+    public var rawValue: String {
+        return "\(owner)/\(name):\(version)"
+    }
+}
+
+// MARK: - ExpressibleByStringLiteral
+
+extension Identifier: ExpressibleByStringLiteral {
+    public init!(stringLiteral value: StringLiteralType) {
+       guard let identifier = Identifier(rawValue: value) else {
+           fatalError("Invalid Identifier string literal: \(value)")
+       }
+
+       self = identifier
+   }
+}

--- a/Tests/ReplicateTests/ClientTests.swift
+++ b/Tests/ReplicateTests/ClientTests.swift
@@ -7,6 +7,12 @@ final class ClientTests: XCTestCase {
     static override func setUp() {
         URLProtocol.registerClass(MockURLProtocol.self)
     }
+    
+    func testRun() async throws {
+        let identifier: Identifier = "test/example:5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa"
+        let output = try await client.run(identifier, input: ["text": "Alice"])
+        XCTAssertEqual(output, ["Hello, Alice!"])
+    }
 
     func testCreatePrediction() async throws {
         let version: Model.Version.ID = "5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa"


### PR DESCRIPTION
Adds a convenience method to `Client` for running a model at a version and waiting for its output:

```swift
let output = try await replicate.run(
    "stability-ai/stable-diffusion:db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf", 
    ["prompt": "a 19th century portrait of a wombat gentleman"]
)

print(output)
// https://replicate.com/api/models/stability-ai/stable-diffusion/files/50fcac81-865d-499e-81ac-49de0cb79264/out-0.png
```