### PR TITLE
Add typealias`Prediction` in default implementation of `Predictable` types

### DIFF
--- a/Sources/Replicate/Predictable.swift
+++ b/Sources/Replicate/Predictable.swift
@@ -16,6 +16,9 @@ public protocol Predictable {
 // MARK: - Default Implementations
 
 extension Predictable {
+    /// The type of prediction created by the model
+    public typealias Prediction = Replicate.Prediction<Input, Output>
+
     /// Creates a prediction.
     ///
     /// - Parameters:
@@ -33,8 +36,8 @@ extension Predictable {
         with client: Client,
         input: Input,
         wait: Bool = false
-    ) async throws -> Prediction<Input, Output> {
-        return try await client.createPrediction(Prediction<Input, Output>.self,
+    ) async throws -> Prediction {
+        return try await client.createPrediction(Prediction.self,
                                                  version: Self.versionID,
                                                  input: input,
                                                  wait: wait)


### PR DESCRIPTION
When working with a type conforming to `Predictable`, this typealias provides a convenient handle on the kind of `Prediction` object created by that type.

For example:

```swift
// https://replicate.com/stability-ai/stable-diffusion
enum StableDiffusion: Predictable {
    static var modelID = "stability-ai/stable-diffusion"
    static let versionID = "db21e45d3f7023abc2a46ee38a23973f6dce16bb082a930b0c49861f96d1e5bf"
    
    typealias Input = [String: String]
    typealias Output = [URL]
}

struct ContentView: View {
    @State private var prompt = ""
    
    // Before: Prediction<[String: String], [URL]>?
    @State private var prediction: StableDiffusion.Prediction? = nil

    // ...
}
```