### PR TITLE
Add support for training endpoints

### DIFF
--- a/Sources/Replicate/Prediction.swift
+++ b/Sources/Replicate/Prediction.swift
@@ -24,35 +24,6 @@ public struct Prediction<Input, Output>: Identifiable where Input: Codable, Outp
         public let predictTime: TimeInterval?
     }
 
-    /// The status of the prediction.
-    public enum Status: String, Hashable, Codable {
-        /// The prediction is starting up.
-        /// If this status lasts longer than a few seconds,
-        /// then it's typically because a new worker is being started to run the prediction.
-        case starting
-
-        /// The `predict()` method of the model is currently running.
-        case processing
-
-        /// The prediction completed successfully.
-        case succeeded
-
-        /// The prediction encountered an error during processing.
-        case failed
-
-        /// The prediction was canceled by the user.
-        case canceled
-
-        public var terminated: Bool {
-            switch self {
-            case .starting, .processing:
-                return false
-            default:
-                return true
-            }
-        }
-    }
-
     /// The unique ID of the prediction.
     /// Can be used to get a single prediction.
     ///

--- a/Sources/Replicate/Status.swift
+++ b/Sources/Replicate/Status.swift
@@ -1,0 +1,28 @@
+/// The status of the prediction or training.
+public enum Status: String, Hashable, Codable {
+    /// The prediction is starting up.
+    /// If this status lasts longer than a few seconds,
+    /// then it's typically because a new worker is being started to run the prediction.
+    case starting
+
+    /// The `predict()` method of the model is currently running.
+    case processing
+
+    /// The prediction completed successfully.
+    case succeeded
+
+    /// The prediction encountered an error during processing.
+    case failed
+
+    /// The prediction was canceled by the user.
+    case canceled
+
+    public var terminated: Bool {
+        switch self {
+        case .starting, .processing:
+            return false
+        default:
+            return true
+        }
+    }
+}

--- a/Sources/Replicate/Status.swift
+++ b/Sources/Replicate/Status.swift
@@ -1,20 +1,20 @@
 /// The status of the prediction or training.
 public enum Status: String, Hashable, Codable {
-    /// The prediction is starting up.
+    /// The prediction or training is starting up.
     /// If this status lasts longer than a few seconds,
     /// then it's typically because a new worker is being started to run the prediction.
     case starting
 
-    /// The `predict()` method of the model is currently running.
+    /// The `predict()` or `train()` method of the model is currently running.
     case processing
 
-    /// The prediction completed successfully.
+    /// The prediction or training completed successfully.
     case succeeded
 
-    /// The prediction encountered an error during processing.
+    /// The prediction or training encountered an error during processing.
     case failed
 
-    /// The prediction was canceled by the user.
+    /// The prediction or training was canceled by the user.
     case canceled
 
     public var terminated: Bool {

--- a/Sources/Replicate/Trainable.swift
+++ b/Sources/Replicate/Trainable.swift
@@ -16,7 +16,7 @@ extension Trainable {
     /// The type of training created by the model
     public typealias Training = Replicate.Training<Input>
 
-    /// Creates a prediction.
+    /// Trains a new model on Replicate.
     ///
     /// - Parameters:
     ///     - client: The client used to make API requests.

--- a/Sources/Replicate/Trainable.swift
+++ b/Sources/Replicate/Trainable.swift
@@ -1,0 +1,37 @@
+/// A type that can train new model versions with known inputs.
+public protocol Trainable {
+    /// The type of the input to the model.
+    associatedtype Input: Codable
+
+    /// The ID of the model.
+    static var modelID: Model.ID { get }
+
+    /// The ID of the model version.
+    static var versionID: Model.Version.ID { get }
+}
+
+// MARK: - Default Implementations
+
+extension Trainable {
+    /// The type of training created by the model
+    public typealias Training = Replicate.Training<Input>
+
+    /// Creates a prediction.
+    ///
+    /// - Parameters:
+    ///     - client: The client used to make API requests.
+    ///     - destination: The desired model to push to
+    ///                    in the format `{owner}/{model_name}`.
+    ///     - input: The input passed to the model.
+    public static func train(
+        with client: Client,
+        destination: Model.ID,
+        input: Input
+    ) async throws -> Training
+    {
+        return try await client.createTraining(Training.self,
+                                               version: Self.versionID,
+                                               destination: destination,
+                                               input: input)
+    }
+}

--- a/Sources/Replicate/Training.swift
+++ b/Sources/Replicate/Training.swift
@@ -1,0 +1,121 @@
+import struct Foundation.Date
+import struct Foundation.URL
+import struct Foundation.TimeInterval
+import struct Dispatch.DispatchTime
+
+/// A training with unspecified inputs and outputs.
+public typealias AnyTraining = Training<[String: Value]>
+
+/// A training made by a model hosted on Replicate.
+public struct Training<Input>: Identifiable where Input: Codable {
+    public typealias ID = String
+
+    public struct Output: Hashable, Codable {
+        public var version: Model.Version.ID
+        public var weights: URL?
+    }
+
+    /// Source for creating a training.
+    public enum Source: String, Codable {
+        /// The training was made on the web.
+        case web
+
+        /// The training was made using the API.
+        case api
+    }
+
+    /// Metrics for the training.
+    public struct Metrics: Hashable {
+        /// How long it took to create the training, in seconds.
+        public let predictTime: TimeInterval?
+    }
+
+    /// The unique ID of the prediction.
+    /// Can be used to get a single prediction.
+    ///
+    /// - SeeAlso: ``Client/getPrediction(id:)``
+    public let id: ID
+
+    /// The version of the model used to create the prediction.
+    public let versionID: Model.Version.ID
+
+    /// Where the prediction was made.
+    public let source: Source?
+
+    /// The model's input as a JSON object.
+    ///
+    /// The input depends on what model you are running.
+    /// To see the available inputs,
+    /// click the "Run with API" tab on the model you are running.
+    /// For example,
+    /// [stability-ai/stable-diffusion](https://replicate.com/stability-ai/stable-diffusion)
+    /// takes `prompt` as an input.
+    ///
+    /// Files should be passed as data URLs or HTTP URLs.
+    public let input: Input
+
+    /// The output of the model for the prediction, if completed successfully.
+    public let output: Output?
+
+    /// The status of the prediction.
+    public let status: Status
+
+    /// The error encountered during the prediction, if any.
+    public let error: Error?
+
+    /// Logging output for the prediction.
+    public let logs: String?
+
+    /// Metrics for the training.
+    public let metrics: Metrics?
+
+    /// When the training was created.
+    public let createdAt: Date
+
+    /// When the training was completed.
+    public let completedAt: Date?
+
+    // MARK: -
+
+    /// Cancel the training.
+    ///
+    /// - Parameters:
+    ///     - client: The client used to make API requests.
+    public mutating func cancel(with client: Client) async throws {
+        self = try await client.cancelTraining(Self.self, id: id)
+    }
+}
+
+// MARK: - Decodable
+
+extension Training: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case versionID = "version"
+        case source
+        case input
+        case output
+        case status
+        case error
+        case logs
+        case metrics
+        case createdAt = "created_at"
+        case completedAt = "completed_at"
+    }
+}
+
+extension Training.Metrics: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case predictTime = "predict_time"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.predictTime = try container.decodeIfPresent(TimeInterval.self, forKey: .predictTime)
+    }
+}
+
+// MARK: - Hashable
+
+extension Training: Equatable where Input: Equatable {}
+extension Training: Hashable where Input: Hashable {}

--- a/Sources/Replicate/Training.swift
+++ b/Sources/Replicate/Training.swift
@@ -30,16 +30,16 @@ public struct Training<Input>: Identifiable where Input: Codable {
         public let predictTime: TimeInterval?
     }
 
-    /// The unique ID of the prediction.
-    /// Can be used to get a single prediction.
+    /// The unique ID of the training.
+    /// Can be used to get a single training.
     ///
-    /// - SeeAlso: ``Client/getPrediction(id:)``
+    /// - SeeAlso: ``Client/getTraining(id:)``
     public let id: ID
 
-    /// The version of the model used to create the prediction.
+    /// The version of the model used to create the training.
     public let versionID: Model.Version.ID
 
-    /// Where the prediction was made.
+    /// Where the training was made.
     public let source: Source?
 
     /// The model's input as a JSON object.
@@ -54,16 +54,16 @@ public struct Training<Input>: Identifiable where Input: Codable {
     /// Files should be passed as data URLs or HTTP URLs.
     public let input: Input
 
-    /// The output of the model for the prediction, if completed successfully.
+    /// The output of the model for the training, if completed successfully.
     public let output: Output?
 
-    /// The status of the prediction.
+    /// The status of the training.
     public let status: Status
 
-    /// The error encountered during the prediction, if any.
+    /// The error encountered during the training, if any.
     public let error: Error?
 
-    /// Logging output for the prediction.
+    /// Logging output for the training.
     public let logs: String?
 
     /// Metrics for the training.

--- a/Tests/ReplicateTests/ClientTests.swift
+++ b/Tests/ReplicateTests/ClientTests.swift
@@ -92,6 +92,36 @@ final class ClientTests: XCTestCase {
         XCTAssertEqual(collection.slug, "super-resolution")
     }
 
+    func testCreateTraining() async throws {
+        let version: Model.Version.ID = "4a056052b8b98f6db8d011a450abbcd09a408ec9280c29f22d3538af1099646a"
+        let destination: Model.ID = "my/fork"
+        let training = try await client.createTraining(version: version, destination: destination, input: ["data": "..."])
+        XCTAssertEqual(training.id, "zz4ibbonubfz7carwiefibzgga")
+        XCTAssertEqual(training.versionID, version)
+        XCTAssertEqual(training.status, .starting)
+    }
+
+    func testGetTraining() async throws {
+        let training = try await client.getTraining(id: "zz4ibbonubfz7carwiefibzgga")
+        XCTAssertEqual(training.id, "zz4ibbonubfz7carwiefibzgga")
+        XCTAssertEqual(training.versionID, "4a056052b8b98f6db8d011a450abbcd09a408ec9280c29f22d3538af1099646a")
+        XCTAssertEqual(training.source, .web)
+        XCTAssertEqual(training.status, .succeeded)
+        XCTAssertEqual(training.createdAt.timeIntervalSinceReferenceDate, 703980786.224, accuracy: 1)
+    }
+
+    func testCancelTraining() async throws {
+        let training = try await client.cancelTraining(id: "zz4ibbonubfz7carwiefibzgga")
+        XCTAssertEqual(training.id, "zz4ibbonubfz7carwiefibzgga")
+    }
+
+    func testGetTrainings() async throws {
+        let trainings = try await client.getTrainings()
+        XCTAssertNil(trainings.previous)
+        XCTAssertEqual(trainings.next, "g5FWfcbO0EdVeR27rkXr0Z6tI0MjrW34ZejxnGzDeND3phpWWsyMGCQD")
+        XCTAssertEqual(trainings.results.count, 1)
+    }
+
     func testUnauthenticated() async throws {
         do {
             let _ = try await Client.unauthenticated.getPredictions()

--- a/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
+++ b/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
@@ -418,6 +418,108 @@ class MockURLProtocol: URLProtocol {
                       "models": []
                     }
                 """#
+            case ("GET", "https://api.replicate.com/v1/trainings"?):
+                statusCode = 200
+                json = #"""
+                    {
+                      "previous": null,
+                      "next": "https://api.replicate.com/v1/trainings?cursor=g5FWfcbO0EdVeR27rkXr0Z6tI0MjrW34ZejxnGzDeND3phpWWsyMGCQD",
+                      "results": [
+                        {
+                          "id": "zz4ibbonubfz7carwiefibzgga",
+                          "version": "4a056052b8b98f6db8d011a450abbcd09a408ec9280c29f22d3538af1099646a",
+                          "urls": {
+                            "get": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq",
+                            "cancel": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq/cancel"
+                          },
+                          "created_at": "2022-04-26T22:13:06.224088Z",
+                          "completed_at": "2022-04-26T22:13:06.580379Z",
+                          "source": "web",
+                          "status": "starting",
+                          "input": {
+                            "data": "..."
+                          },
+                          "output": null,
+                          "error": null,
+                          "logs": null,
+                          "metrics": {}
+                        }
+                      ]
+                    }
+                """#
+            case ("POST", "https://api.replicate.com/v1/trainings"?):
+                statusCode = 201
+
+                json = #"""
+                    {
+                      "id": "zz4ibbonubfz7carwiefibzgga",
+                      "version": "4a056052b8b98f6db8d011a450abbcd09a408ec9280c29f22d3538af1099646a",
+                      "urls": {
+                        "get": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq",
+                        "cancel": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq/cancel"
+                      },
+                      "created_at": "2022-04-26T22:13:06.224088Z",
+                      "completed_at": "2022-04-26T22:13:06.580379Z",
+                      "source": "web",
+                      "status": "starting",
+                      "input": {
+                        "data": "..."
+                      },
+                      "output": null,
+                      "error": null,
+                      "logs": null,
+                      "metrics": {}
+                    }
+                """#
+            case ("GET", "https://api.replicate.com/v1/trainings/zz4ibbonubfz7carwiefibzgga"?):
+                statusCode = 200
+                json = #"""
+                    {
+                      "id": "zz4ibbonubfz7carwiefibzgga",
+                      "version": "4a056052b8b98f6db8d011a450abbcd09a408ec9280c29f22d3538af1099646a",
+                      "urls": {
+                        "get": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq",
+                        "cancel": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq/cancel"
+                      },
+                      "created_at": "2023-04-23T22:13:06.224088Z",
+                      "completed_at": "2023-04-23T22:15:06.224088Z",
+                      "source": "web",
+                      "status": "succeeded",
+                      "input": {
+                        "data": "..."
+                      },
+                      "output": {
+                        "version": "b024d792ace1084d2504b2fc3012f013cef3b99842add1e7d82d2136ea1b78ac",
+                        "weights": "https://relicate.delivery/example-weights.tar.gz"
+                      },
+                      "error": null,
+                      "logs": "",
+                      "metrics": {}
+                    }
+                """#
+            case ("POST", "https://api.replicate.com/v1/trainings/zz4ibbonubfz7carwiefibzgga/cancel"?):
+                statusCode = 200
+                json = #"""
+                    {
+                      "id": "zz4ibbonubfz7carwiefibzgga",
+                      "version": "4a056052b8b98f6db8d011a450abbcd09a408ec9280c29f22d3538af1099646a",
+                      "urls": {
+                        "get": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq",
+                        "cancel": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq/cancel"
+                      },
+                      "created_at": "2023-04-23T22:13:06.224088Z",
+                      "completed_at": "2023-04-23T22:15:06.224088Z",
+                      "source": "web",
+                      "status": "canceled",
+                      "input": {
+                        "data": "..."
+                      },
+                      "output": null,
+                      "error": null,
+                      "logs": "",
+                      "metrics": {}
+                    }
+                """#
             default:
                 client?.urlProtocol(self, didFailWithError: URLError(.badURL))
                 return


### PR DESCRIPTION
This PR adds `trainings.create`, `trainings.get`, `trainings.list`, and `trainings.cancel` methods to the client.

See https://replicate.com/docs/reference/http#trainings.create