### PR TITLE
Add `baseURLString` and `userAgent` properties to `Client`

### DIFF
--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -8,11 +8,19 @@ import FoundationNetworking
 ///
 /// See https://replicate.com/docs/reference/http
 public class Client {
+    /// The base URL for requests made by the client.
     public let baseURLString: String
+
+    /// The value for the `User-Agent` header sent in requests, if any.
     public let userAgent: String?
+
+    /// The API token used in the `Authorization` header sent in requests.
     private let token: String
+
+    /// The underlying client session.
     internal var session = URLSession(configuration: .default)
 
+    /// The retry policy for requests made by the client.
     public var retryPolicy: RetryPolicy = .default
 
     /// Creates a client with the specified API token.

--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -8,6 +8,8 @@ import FoundationNetworking
 ///
 /// See https://replicate.com/docs/reference/http
 public class Client {
+    public let baseURLString: String
+    public let userAgent: String?
     private let token: String
     internal var session = URLSession(configuration: .default)
 
@@ -19,7 +21,19 @@ public class Client {
     /// [account page](https://replicate.com/account).
     ///
     /// - Parameter token: The API token.
-    public init(token: String) {
+    public init(
+        baseURLString: String = "https://api.replicate.com/v1/",
+        userAgent: String? = nil,
+        token: String
+    )
+    {
+        var baseURLString = baseURLString
+        if !baseURLString.hasSuffix("/") {
+            baseURLString = baseURLString.appending("/")
+        }
+
+        self.baseURLString = baseURLString
+        self.userAgent = userAgent
         self.token = token
     }
 
@@ -329,7 +343,7 @@ public class Client {
                                      _ path: String,
                                      params: [String: Value]? = nil)
     async throws -> T {
-        var urlComponents = URLComponents(string: "https://api.replicate.com/v1/" + path)
+        var urlComponents = URLComponents(string: self.baseURLString.appending(path))
         var httpBody: Data? = nil
 
         switch method {
@@ -360,6 +374,10 @@ public class Client {
         if let httpBody {
             request.httpBody = httpBody
             request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        if let userAgent {
+            request.addValue(userAgent, forHTTPHeaderField: "User-Agent")
         }
 
         let (data, response) = try await session.data(for: request)

--- a/Tests/ReplicateTests/ClientTests.swift
+++ b/Tests/ReplicateTests/ClientTests.swift
@@ -122,6 +122,12 @@ final class ClientTests: XCTestCase {
         XCTAssertEqual(trainings.results.count, 1)
     }
 
+    func testCustomBaseURL() async throws {
+        let client = Client(baseURLString: "https://v1.replicate.proxy", token: MockURLProtocol.validToken).mocked
+        let collection = try await client.getModelCollection("super-resolution")
+        XCTAssertEqual(collection.slug, "super-resolution")
+    }
+
     func testUnauthenticated() async throws {
         do {
             let _ = try await Client.unauthenticated.getPredictions()

--- a/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
+++ b/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
@@ -408,7 +408,8 @@ class MockURLProtocol: URLProtocol {
                         "openapi_schema": {}
                     }
                 """#
-            case ("GET", "https://api.replicate.com/v1/collections/super-resolution"?):
+            case ("GET", "https://api.replicate.com/v1/collections/super-resolution"?),
+                ("GET", "https://v1.replicate.proxy/collections/super-resolution"?):
                 statusCode = 200
                 json = #"""
                     {
@@ -567,7 +568,7 @@ extension Client {
         return Client(token: "").mocked
     }
 
-    private var mocked: Self {
+    var mocked: Self {
         let configuration = session.configuration
         configuration.protocolClasses = [MockURLProtocol.self]
         session = URLSession(configuration: configuration)


### PR DESCRIPTION
This PR brings the Swift library more in line with the JS and Python libraries by adding options to customize the base URL and user agent header of the client used to communicate with Replicate's API.

A custom base URL can be helpful for making requests against a proxied instance of Replicate's API, and a custom user agent can help distinguish API traffic from apps.