### PR TITLE
Add support for `collections.list` endpoint

### DIFF
--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -201,6 +201,15 @@ public class Client {
         return try await fetch(.get, "models/\(id)/versions/\(version)")
     }
 
+    /// List collections of models
+    /// - Parameters:
+    ///     - Parameter cursor: A pointer to a page of results to fetch.
+    public func listModelCollections(cursor: Pagination.Cursor? = nil)
+        async throws -> Pagination.Page<Model.Collection>
+    {
+        return try await fetch(.get, "collections")
+    }
+
     /// Get a collection of models
     ///
     /// - Parameters:

--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -127,6 +127,26 @@ public class Client {
         }
     }
 
+    @available(*, deprecated, renamed: "listPredictions(_:cursor:)")
+    public func getPredictions<Input: Codable, Output: Codable>(
+        _ type: Prediction<Input, Output>.Type = AnyPrediction.self,
+        cursor: Pagination.Cursor? = nil
+    ) async throws -> Pagination.Page<Prediction<Input, Output>>
+    {
+        return try await listPredictions(type, cursor: cursor)
+    }
+
+    /// List predictions
+    ///
+    /// - Parameter cursor: A pointer to a page of results to fetch.
+    public func listPredictions<Input: Codable, Output: Codable>(
+        _ type: Prediction<Input, Output>.Type = AnyPrediction.self,
+        cursor: Pagination.Cursor? = nil
+    ) async throws -> Pagination.Page<Prediction<Input, Output>>
+    {
+        return try await fetch(.get, "predictions", cursor: cursor)
+    }
+
     /// Get a prediction
     ///
     /// - Parameter id: The ID of the prediction you want to fetch.
@@ -147,17 +167,6 @@ public class Client {
         return try await fetch(.post, "predictions/\(id)/cancel")
     }
 
-    /// Get a list of predictions
-    ///
-    /// - Parameter cursor: A pointer to a page of results to fetch.
-    public func getPredictions<Input: Codable, Output: Codable>(
-        _ type: Prediction<Input, Output>.Type = AnyPrediction.self,
-        cursor: Pagination.Cursor? = nil
-    ) async throws -> Pagination.Page<Prediction<Input, Output>>
-    {
-        return try await fetch(.get, "predictions", cursor: cursor)
-    }
-
     /// Get a model
     ///
     /// - Parameters:
@@ -171,7 +180,16 @@ public class Client {
         return try await fetch(.get, "models/\(id)")
     }
 
-    /// Get a list of model versions
+
+    @available(*, deprecated, renamed: "listModelVersions(_:cursor:)")
+    public func getModelVersions(_ id: Model.ID,
+                                 cursor: Pagination.Cursor? = nil)
+        async throws -> Pagination.Page<Model.Version>
+    {
+        return try await listModelVersions(id, cursor: cursor)
+    }
+
+    /// List model versions
     ///
     /// - Parameters:
     ///    - id: The model identifier, comprising
@@ -179,7 +197,7 @@ public class Client {
     ///          the name of the model.
     ///          For example, "stability-ai/stable-diffusion".
     ///    - cursor: A pointer to a page of results to fetch.
-    public func getModelVersions(_ id: Model.ID,
+    public func listModelVersions(_ id: Model.ID,
                                  cursor: Pagination.Cursor? = nil)
         async throws -> Pagination.Page<Model.Version>
     {
@@ -282,6 +300,26 @@ public class Client {
         return try await fetch(.post, "trainings", params: params)
     }
 
+    @available(*, deprecated, renamed: "listTrainings(_:cursor:)")
+    public func getTrainings<Input: Codable>(
+        _ type: Training<Input>.Type = AnyTraining.self,
+        cursor: Pagination.Cursor? = nil
+    ) async throws -> Pagination.Page<Training<Input>>
+    {
+        return try await listTrainings(type, cursor: cursor)
+    }
+
+    /// List trainings
+    ///
+    /// - Parameter cursor: A pointer to a page of results to fetch.
+    public func listTrainings<Input: Codable>(
+        _ type: Training<Input>.Type = AnyTraining.self,
+        cursor: Pagination.Cursor? = nil
+    ) async throws -> Pagination.Page<Training<Input>>
+    {
+        return try await fetch(.get, "trainings", cursor: cursor)
+    }
+
     /// Get a training
     ///
     /// - Parameter id: The ID of the training you want to fetch.
@@ -302,17 +340,6 @@ public class Client {
     ) async throws -> Training<Input>
     {
         return try await fetch(.post, "trainings/\(id)/cancel")
-    }
-
-    /// Get a list of trainings
-    ///
-    /// - Parameter cursor: A pointer to a page of results to fetch.
-    public func getTrainings<Input: Codable>(
-        _ type: Training<Input>.Type = AnyTraining.self,
-        cursor: Pagination.Cursor? = nil
-    ) async throws -> Pagination.Page<Training<Input>>
-    {
-        return try await fetch(.get, "trainings", cursor: cursor)
     }
 
     // MARK: -

--- a/Tests/ReplicateTests/ClientTests.swift
+++ b/Tests/ReplicateTests/ClientTests.swift
@@ -62,7 +62,7 @@ final class ClientTests: XCTestCase {
     }
 
     func testGetPredictions() async throws {
-        let predictions = try await client.getPredictions()
+        let predictions = try await client.listPredictions()
         XCTAssertNil(predictions.previous)
         XCTAssertEqual(predictions.next, "cD0yMDIyLTAxLTIxKzIzJTNBMTglM0EyNC41MzAzNTclMkIwMCUzQTAw")
         XCTAssertEqual(predictions.results.count, 1)
@@ -75,7 +75,7 @@ final class ClientTests: XCTestCase {
     }
 
     func testGetModelVersions() async throws {
-        let versions = try await client.getModelVersions("replicate/hello-world")
+        let versions = try await client.listModelVersions("replicate/hello-world")
         XCTAssertNil(versions.previous)
         XCTAssertNil(versions.next)
         XCTAssertEqual(versions.results.count, 2)
@@ -122,7 +122,7 @@ final class ClientTests: XCTestCase {
     }
 
     func testGetTrainings() async throws {
-        let trainings = try await client.getTrainings()
+        let trainings = try await client.listTrainings()
         XCTAssertNil(trainings.previous)
         XCTAssertEqual(trainings.next, "g5FWfcbO0EdVeR27rkXr0Z6tI0MjrW34ZejxnGzDeND3phpWWsyMGCQD")
         XCTAssertEqual(trainings.results.count, 1)
@@ -130,7 +130,7 @@ final class ClientTests: XCTestCase {
 
     func testUnauthenticated() async throws {
         do {
-            let _ = try await Client.unauthenticated.getPredictions()
+            let _ = try await Client.unauthenticated.listPredictions()
             XCTFail("unauthenticated requests should fail")
         } catch {
             guard let error = error as? Replicate.Error else {

--- a/Tests/ReplicateTests/ClientTests.swift
+++ b/Tests/ReplicateTests/ClientTests.swift
@@ -87,6 +87,12 @@ final class ClientTests: XCTestCase {
         XCTAssertEqual(version.id, "5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa")
     }
 
+    func testListModelCollections() async throws {
+        let collections = try await client.listModelCollections()
+        XCTAssertEqual(collections.results.count, 1)
+        XCTAssertEqual(collections.results.first?.slug, "super-resolution")
+    }
+
     func testGetModelCollection() async throws {
         let collection = try await client.getModelCollection("super-resolution")
         XCTAssertEqual(collection.slug, "super-resolution")

--- a/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
+++ b/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
@@ -408,6 +408,22 @@ class MockURLProtocol: URLProtocol {
                         "openapi_schema": {}
                     }
                 """#
+            case ("GET", "https://api.replicate.com/v1/collections"?):
+                statusCode = 200
+                json = #"""
+                    {
+                      "results": [
+                        {
+                          "name": "Super resolution",
+                          "slug": "super-resolution",
+                          "description": "Upscaling models that create high-quality images from low-quality images.",
+                          "models": []
+                        }
+                      ],
+                      "next": null,
+                      "previous": null
+                    }
+                """#
             case ("GET", "https://api.replicate.com/v1/collections/super-resolution"?):
                 statusCode = 200
                 json = #"""


### PR DESCRIPTION
See https://replicate.com/docs/reference/http#collections.list

> **Warning**
> This PR renames client methods for list endpoints (for example, `getPredictions` -> `listPredictions`). The old methods are deprecated and be removed in a future release.