### PR TITLE
Allow `Collection.models` to be `nil`

### DIFF
--- a/Sources/Replicate/Model.swift
+++ b/Sources/Replicate/Model.swift
@@ -39,7 +39,7 @@ public struct Model: Hashable {
         public let description: String
 
         /// A list of models in the collection.
-        public let models: [Model]
+        public let models: [Model]?
     }
 
     /// The name of the user or organization that owns the model.

--- a/Tests/ReplicateTests/ClientTests.swift
+++ b/Tests/ReplicateTests/ClientTests.swift
@@ -90,7 +90,13 @@ final class ClientTests: XCTestCase {
     func testListModelCollections() async throws {
         let collections = try await client.listModelCollections()
         XCTAssertEqual(collections.results.count, 1)
+
         XCTAssertEqual(collections.results.first?.slug, "super-resolution")
+        XCTAssertEqual(collections.results.first?.models, nil)
+
+        let collection = try await client.getModelCollection(collections.results.first!.slug)
+        XCTAssertEqual(collection.slug, "super-resolution")
+        XCTAssertEqual(collection.models, [])
     }
 
     func testGetModelCollection() async throws {

--- a/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
+++ b/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
@@ -417,7 +417,6 @@ class MockURLProtocol: URLProtocol {
                           "name": "Super resolution",
                           "slug": "super-resolution",
                           "description": "Upscaling models that create high-quality images from low-quality images.",
-                          "models": []
                         }
                       ],
                       "next": null,


### PR DESCRIPTION
Related to #33 

This PR makes the `models` property in `Collection` optional to support partial response from `GET /v1/collections`.